### PR TITLE
NMC 1189 Selection Style of cell set to none.

### DIFF
--- a/iOSClient/ScanDocument/NMCViews/PasswordInputField.swift
+++ b/iOSClient/ScanDocument/NMCViews/PasswordInputField.swift
@@ -19,6 +19,7 @@ class PasswordInputField: XLFormBaseCell,UITextFieldDelegate {
         fileNameInputTextField.isSecureTextEntry = true
         fileNameInputTextField.delegate = self
         separatorBottom.backgroundColor = NCBrandColor.shared.systemGray4
+        self.selectionStyle = .none
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {


### PR DESCRIPTION
NMC 1189 Scan document - Password field highlighted on tap instead of putting cursor into it