### PR TITLE
NMC 1490 - Added two  localizable strings for downloading

### DIFF
--- a/iOSClient/Supporting Files/de.lproj/Localizable.strings
+++ b/iOSClient/Supporting Files/de.lproj/Localizable.strings
@@ -517,6 +517,7 @@
 "_files_"                       = "Dateien";
 "_file_"                        = "Datei";
 "_folder_blocked_"              = "Ordner gesperrt";
+"_downloading_"                 = "Wird heruntergeladen";
 "_downloading_progress_"        = "Das Herunterladen von Dateien wird eingeleitet …";
 "_no_file_pull_down_"           = "Laden Sie eine Datei hoch oder ziehen Sie herunter, um zu aktualisieren";
 "_browse_images_"               = "Bilder durchsuchen";

--- a/iOSClient/Supporting Files/en.lproj/Localizable.strings
+++ b/iOSClient/Supporting Files/en.lproj/Localizable.strings
@@ -542,6 +542,7 @@
 "_file_"                        = "file";
 "_folder_blocked_"              = "Folder blocked";
 "_downloading_progress_"        = "Initiating download of files…";
+"_downloading_"                 = "Downloading";
 "_no_file_pull_down_"           = "Upload a file or pull down to refresh";
 "_browse_images_"               = "Browse images";
 "_synchronized_folder_"         = "Keep the folder synchronized";


### PR DESCRIPTION
NMC 1490 Changed title for "downloading" when copy a file.