### PR TITLE
NMC 1593 - Condition added for encrypted folder for paste option

### DIFF
--- a/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
+++ b/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
@@ -1030,7 +1030,7 @@ class NCCollectionViewCommon: UIViewController, UIGestureRecognizerDelegate, UIS
 
         becomeFirstResponder()
 
-        if serverUrl != "" {
+        if serverUrl != "" && !isEncryptedFolder {
             listMenuItems.append(UIMenuItem(title: NSLocalizedString("_paste_file_", comment: ""), action: #selector(pasteFilesMenu)))
         }
 


### PR DESCRIPTION
NMC 1593 - Copy files and paste it to encrypted folder shows inappropriate error