### PR TITLE
NMC 1734  - Updated german traslation for "Cancel" button

### DIFF
--- a/iOSClient/Settings/NCEndToEndInitialize.swift
+++ b/iOSClient/Settings/NCEndToEndInitialize.swift
@@ -196,7 +196,7 @@ class NCEndToEndInitialize: NSObject {
                     }
                 })
 
-                let cancel = UIAlertAction(title: "Cancel", style: .cancel) { _ -> Void in
+                let cancel = UIAlertAction(title: NSLocalizedString("Cancel", comment: "") , style: .cancel) { _ -> Void in
                 }
 
                 alertController.addAction(ok)


### PR DESCRIPTION
NMC 1734 -  Enter Passphrase Dialog: Missing translation for "Cancel" Button.