### PR TITLE
NMC 1743 - changed localized string

### DIFF
--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -518,7 +518,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate {
                 }
             } else {
                 let alertController = UIAlertController(title: NSLocalizedString("_invalid_page_", comment: ""),
-                                                        message: NSLocalizedString("_the_entered_page_number_does_not_exist_", comment: ""),
+                                                        message: NSLocalizedString("_the_entered_page_number_doesn't_exist_", comment: ""),
                                                         preferredStyle: .alert)
                 alertController.addAction(UIAlertAction(title: NSLocalizedString("_ok_", comment: ""), style: .default, handler: nil))
                 self.present(alertController, animated: true, completion: nil)


### PR DESCRIPTION
NMC 1743 - Document - Untranslated / technical error message shown when skipping to page that is not available