### PR TITLE
NMC 337 - Removed UISupportsDocumentBrowser key from plist for hiding…

### DIFF
--- a/iOSClient/Brand/iOSClient.plist
+++ b/iOSClient/Brand/iOSClient.plist
@@ -107,8 +107,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
-	<key>UISupportsDocumentBrowser</key>
-	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 	<key>UTExportedTypeDeclarations</key>


### PR DESCRIPTION
Removed UISupportsDocumentBrowser key from plist for hiding the document storage option from app settings