### PR TITLE
NMC 2373 - Selection hidden for E2EFolders in List and Grid mode

### DIFF
--- a/iOSClient/Main/Collection Common/NCGridCell.swift
+++ b/iOSClient/Main/Collection Common/NCGridCell.swift
@@ -180,7 +180,7 @@ class NCGridCell: UICollectionViewCell, UIGestureRecognizerDelegate, NCCellProto
     }
 
     func selected(_ status: Bool) {
-        guard let metadata = NCManageDatabase.shared.getMetadataFromOcId(objectId), !metadata.isDownloadUpload else {
+        guard let metadata = NCManageDatabase.shared.getMetadataFromOcId(objectId), !metadata.isDownloadUpload, !metadata.e2eEncrypted else {
             imageSelect.isHidden = true
             imageVisualEffect.isHidden = true
             return

--- a/iOSClient/Main/Collection Common/NCListCell.swift
+++ b/iOSClient/Main/Collection Common/NCListCell.swift
@@ -253,7 +253,7 @@ class NCListCell: UICollectionViewCell, UIGestureRecognizerDelegate, NCCellProto
     }
 
     func selected(_ status: Bool) {
-        guard let metadata = NCManageDatabase.shared.getMetadataFromOcId(objectId), !metadata.isDownloadUpload else {
+        guard let metadata = NCManageDatabase.shared.getMetadataFromOcId(objectId), !metadata.isDownloadUpload, !metadata.e2eEncrypted else {
             backgroundView = nil
             separator.isHidden = false
             return


### PR DESCRIPTION
NMC 2373 - iOS: Multi selection not possible for encrypted folder.