### PR TITLE
NMC 1757 - file - videos disappear from the app after the copy process is cancelled 

### DIFF
--- a/iOSClient/Utility/ParallelWorker.swift
+++ b/iOSClient/Utility/ParallelWorker.swift
@@ -57,12 +57,12 @@ class ParallelWorker {
             hud.tapOnHUDViewBlock = { hud in
                 self.isCancelled = true
                 // Cancel all download / upload
-                for uploadRequest in NCNetworking.shared.uploadRequest {
-                    uploadRequest.value.cancel()
-                }
-                for downloadRequest in NCNetworking.shared.downloadRequest {
-                    downloadRequest.value.cancel()
-                }
+//                for uploadRequest in NCNetworking.shared.uploadRequest {
+//                    uploadRequest.value.cancel()
+//                }
+//                for downloadRequest in NCNetworking.shared.downloadRequest {
+//                    downloadRequest.value.cancel()
+//                }
                 hud.dismiss()
             }
             self.hud = hud


### PR DESCRIPTION
NMC 1757 - File - Videos disappear from the app after the copy process is cancelled in the "Share" section