### PR TITLE
NMC 2397- Error message update for wrong passphares

### DIFF
--- a/iOSClient/Settings/NCEndToEndInitialize.swift
+++ b/iOSClient/Settings/NCEndToEndInitialize.swift
@@ -159,8 +159,8 @@ class NCEndToEndInitialize: NSObject {
                         CCUtility.setEndToEndPrivateKey(self.appDelegate.account, privateKey: privateKey)
                     } else {
 
-                        let error = NKError(errorCode: NCGlobal.shared.errorInternalError, errorDescription: "Serious internal error to decrypt Private Key")
-                        NCContentPresenter.shared.messageNotification("E2E decrypt privateKey", error: error, delay: NCGlobal.shared.dismissAfterSecond, type: NCContentPresenter.messageType.error, priority: .max)
+                        let error = NKError(errorCode: NCGlobal.shared.errorInternalError, errorDescription: NSLocalizedString("_e2e_error_incorrect_passphrase_", comment: ""))
+                        NCContentPresenter.shared.messageNotification(NSLocalizedString("_e2e_error_passphrase_title", comment: ""), error: error, delay: NCGlobal.shared.dismissAfterSecond, type: NCContentPresenter.messageType.error, priority: .max)
 
                         return
                     }


### PR DESCRIPTION
This PR contain localization changes for wrong passphrase alert 
![Simulator Screenshot - iPhone 14 Pro Max - 2023-07-11 at 17 15 32](https://github.com/nextmcloud/ios/assets/96108296/7aec7d24-eeba-4dfc-83aa-dacded65f65b)
![Simulator Screenshot - iPhone 14 Pro Max - 2023-07-11 at 17 21 18](https://github.com/nextmcloud/ios/assets/96108296/631998c6-3e31-45e2-b02d-91fa4023529e)
